### PR TITLE
Use link to create a single dll.

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -1,5 +1,6 @@
 mkdir bin
-ilasm /dll src\PtrUtils.il /out:bin\System.Slice.netmodule
-csc /t:library /debug:pdbonly /unsafe /o+ /addmodule:bin\System.Slice.netmodule /out:bin\System.Slice.dll src\*.cs
+ilasm /dll src\PtrUtils.il /out:bin\System.Slice.Core.netmodule
+csc /t:module /debug:pdbonly /unsafe /o+ /addmodule:bin\System.Slice.Core.netmodule /out:bin\System.Slice.netmodule src\*.cs 
+link /dll /out:bin\System.Slice.dll bin\System.Slice.Core.netmodule bin\System.Slice.netmodule 
 csc /debug:pdbonly /unsafe /r:bin\System.Slice.dll /out:bin\System.Slice.Test.exe tests\*.cs
 


### PR DESCRIPTION
Gets rid of the netmodule, specifically.
